### PR TITLE
Make tokio optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,12 @@ edition = "2018"
 license = "MIT"
 
 [dependencies]
-futures = "0.3"
-tokio = { version = "1.14", features = ["fs", "io-util"] }
+futures = {version = "0.3", optional = true }
+tokio = { version = "1.14", features = ["fs", "io-util"], optional = true}
 
 [dev-dependencies]
 tokio = { version = "1.14", features = ["full"] }
+
+[features]
+default = []
+tokio = ["dep:tokio", "futures"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 license = "MIT"
 
 [dependencies]
-futures = {version = "0.3", optional = true }
+futures-util = {version = "0.3", optional = true, default-features = false }
 tokio = { version = "1.14", features = ["fs", "io-util"], optional = true}
 
 [dev-dependencies]
@@ -19,4 +19,4 @@ tokio = { version = "1.14", features = ["full"] }
 
 [features]
 default = []
-tokio = ["dep:tokio", "futures"]
+tokio = ["dep:tokio", "futures-util"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,15 +11,21 @@
 //! to that of writing a `loop` manually, due to the avoidance of allocations.
 #![doc(html_root_url = "https://docs.rs/bytelines/2.4.0")]
 use ::std::io::BufRead;
+
+#[cfg(feature = "tokio")]
 use ::tokio::io::AsyncBufRead;
 
 // mods
 mod std;
-mod tokio;
 mod util;
+
+#[cfg(feature = "tokio")]
+mod tokio;
 
 // expose all public APIs to keep the v2.x interface the same
 pub use crate::std::{ByteLines, ByteLinesIter, ByteLinesReader};
+
+#[cfg(feature = "tokio")]
 pub use crate::tokio::AsyncByteLines;
 
 /// Creates a new line reader from a stdlib `BufRead`.
@@ -32,6 +38,7 @@ where
 }
 
 /// Creates a new line reader from a Tokio `AsyncBufRead`.
+#[cfg(feature = "tokio")]
 #[inline]
 pub fn from_tokio<B>(reader: B) -> AsyncByteLines<B>
 where

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -1,5 +1,5 @@
 //! Module exposing APIs based around `AsyncBufRead` from Tokio.
-use futures::stream::{self, Stream};
+use futures_util::stream::{self, Stream};
 use tokio::io::{AsyncBufRead, AsyncBufReadExt};
 
 use std::io::Error;


### PR DESCRIPTION
Would you be willing to accept this (or similar) PR? I use bytelines pretty extensively but rarely use tokio, and this cuts down on the dependency tree by hiding it behind a "tokio" feature flag.

No worries either way, cheers.