### PR TITLE
Implements Lender for bytelines

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,7 @@ edition = "2018"
 license = "MIT"
 
 [dependencies]
-#hrtb-lending-iterator = "0.1.0"
-hrtb-lending-iterator = { git = "https://github.com/vigna/hrtb-lending-iterator-rs"}
+hrtb-lending-iterator = "0.2.0"
 futures = "0.3"
 tokio = { version = "1.14", features = ["fs", "io-util"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ edition = "2018"
 license = "MIT"
 
 [dependencies]
+#hrtb-lending-iterator = "0.1.0"
+hrtb-lending-iterator = { git = "https://github.com/vigna/hrtb-lending-iterator-rs"}
 futures = "0.3"
 tokio = { version = "1.14", features = ["fs", "io-util"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ edition = "2018"
 license = "MIT"
 
 [dependencies]
-hrtb-lending-iterator = "0.2.0"
 futures = "0.3"
+lender = "0.1.7"
 tokio = { version = "1.14", features = ["fs", "io-util"] }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ mod util;
 // expose all public APIs to keep the v2.x interface the same
 pub use crate::std::{ByteLines, ByteLinesIter, ByteLinesReader};
 pub use crate::tokio::AsyncByteLines;
+pub use lender::*;
 
 /// Creates a new line reader from a stdlib `BufRead`.
 #[inline]

--- a/src/std.rs
+++ b/src/std.rs
@@ -84,7 +84,7 @@ where
 }
 
 impl<'a, B: BufRead> LendingIteratorItem<'a> for ByteLines<B> {
-    type T = Result<&'a [u8], Error>;
+    type Type = Result<&'a [u8], Error>;
 }
 
 impl<B: BufRead> LendingIterator for ByteLines<B> {

--- a/src/std.rs
+++ b/src/std.rs
@@ -1,4 +1,5 @@
 //! Module exposing APIs based around `BufRead` from stdlib.
+use hrtb_lending_iterator::*;
 use std::io::{BufRead, Error};
 
 /// Provides iteration over bytes of input, split by line.
@@ -12,6 +13,7 @@ use std::io::{BufRead, Error};
 /// use bytelines::*;
 /// use std::fs::File;
 /// use std::io::BufReader;
+/// use hrtb_lending_iterator::*;
 ///
 /// // construct our iterator from our file input
 /// let file = File::open("./res/numbers.txt").unwrap();
@@ -64,15 +66,6 @@ where
             reader: buf,
         }
     }
-
-    /// Retrieves a reference to the next line of bytes in the reader (if any).
-    pub fn next(&mut self) -> Option<Result<&[u8], Error>> {
-        self.buffer.clear();
-        crate::util::handle_line(
-            self.reader.read_until(b'\n', &mut self.buffer),
-            &mut self.buffer,
-        )
-    }
 }
 
 /// `IntoIterator` conversion for `ByteLines` to provide `Iterator` APIs.
@@ -87,6 +80,21 @@ where
     #[inline]
     fn into_iter(self) -> ByteLinesIter<B> {
         ByteLinesIter { inner: self }
+    }
+}
+
+impl<'a, B: BufRead> LendingIteratorItem<'a> for ByteLines<B> {
+    type T = Result<&'a [u8], Error>;
+}
+
+impl<B: BufRead> LendingIterator for ByteLines<B> {
+    /// Retrieves a reference to the next line of bytes in the reader (if any).
+    fn next(&mut self) -> Option<Item<'_, Self>> {
+        self.buffer.clear();
+        crate::util::handle_line(
+            self.reader.read_until(b'\n', &mut self.buffer),
+            &mut self.buffer,
+        )
     }
 }
 
@@ -181,7 +189,7 @@ mod tests {
         let file = File::open("./res/numbers.txt").unwrap();
         let mut lines = Vec::new();
 
-        for line in BufReader::new(file).byte_lines().into_iter() {
+        for line in IntoIterator::into_iter(BufReader::new(file).byte_lines()) {
             let line = line.unwrap();
             let line = String::from_utf8(line).unwrap();
 
@@ -198,7 +206,7 @@ mod tests {
         let file = File::open("./res/empty.txt").unwrap();
         let mut lines = Vec::new();
 
-        for line in BufReader::new(file).byte_lines().into_iter() {
+        for line in IntoIterator::into_iter(BufReader::new(file).byte_lines()) {
             let line = line.unwrap();
             let line = String::from_utf8(line).unwrap();
 
@@ -207,5 +215,21 @@ mod tests {
 
         assert_eq!(lines.len(), 1);
         assert_eq!(lines[0], "");
+    }
+
+    #[test]
+    fn test_buf_read() {
+        let buf_reader = BufReader::new(File::open("./res/numbers.txt").unwrap());
+        let mut lines = Vec::new();
+
+        for_lend! { line in buf_reader.byte_lines() =>
+            let line = line.unwrap();
+            let line = String::from_utf8(line.to_vec()).unwrap();
+            lines.push(line);
+        }
+
+        for i in 0..9 {
+            assert_eq!(lines[i], format!("{}", i));
+        }
     }
 }


### PR DESCRIPTION
This PR makes bytelines implement the LendingIterator trait from https://github.com/vigna/hrtb-lending-iterator-rs. The changes are minimal, but now standard iterator operations such as Map, Take, etc. are available. There's just a few methods, but we're working on expanding what is available. Our goal is to make everything that makes sense for a lending iterator available.